### PR TITLE
Add arch aur package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,9 @@ make
 sudo make install
 ```
 
+The package can be installed on Arch using 
+```
+yaourt -S screenshot-applet
+```
+
 A package in the Solus repo will soon be available.


### PR DESCRIPTION
I've created an AUR package for Arch.  If there's something i must change, don't hesitate ;) 
The build is not working right now, i might need some help to figure this out :) 

```
/usr/include/budgie-desktop/plugin.h:15:25: erreur fatale : applet-info.h : Aucun fichier ou dossier de ce type
 #include <applet-info.h>
```

I think it's might due to an old Budgie version ? I will try the git version

Update: Works fine with `budgie-desktop-git` we just need to wait until the latest version of budgie desktop  to be released :) 
